### PR TITLE
Adding mart models and fixing intermediate models

### DIFF
--- a/models/intermediate/int_ae_local_bike__order_items.sql
+++ b/models/intermediate/int_ae_local_bike__order_items.sql
@@ -4,8 +4,8 @@ SELECT
   oi.product_id,
   oi.item_quantity,
   oi.total_order_item_amount,
-  oi.item_quantity*oi.item_price*oi.discount AS discount_amount,
+  ROUND(oi.item_quantity*oi.item_price*oi.discount,2) AS discount_amount,
   o.customer_id,
   o.order_date
 FROM {{ref("stg_ae_local_bike__order_items")}} oi
-LEFT JOIN {{ref("int_ae_local_bike__orders")}} o ON oi.order_id = o.order_id
+LEFT JOIN {{ref("stg_ae_local_bike__orders")}} o ON oi.order_id = o.order_id

--- a/models/intermediate/int_ae_local_bike__products.sql
+++ b/models/intermediate/int_ae_local_bike__products.sql
@@ -1,5 +1,6 @@
 SELECT
-    CONCAT(p.product_id,' - ',p.product_name) AS product_name,
+    p.product_name,
+    p.product_id,
     p.product_price,
     c.category_name
 FROM {{ref("stg_ae_local_bike__products")}} p

--- a/models/mart/mrt_ae_local_bike__customers.sql
+++ b/models/mart/mrt_ae_local_bike__customers.sql
@@ -1,0 +1,15 @@
+SELECT 
+    o.customer_id,
+    o.store_name,
+    MAX(o.order_date) AS max_order_date,
+    MIN(o.order_date) AS min_order_date,
+    COUNT(DISTINCT o.order_id) AS nb_of_orders,
+    SUM(oi.item_quantity) AS nb_of_items,
+    SUM(oi.total_order_item_amount) AS total_order_amount,
+    AVG(oi.total_order_item_amount) AS avg_order_amount,
+    ROUND(DATE_DIFF(DATE(MAX(o.order_date)),DATE(MIN(o.order_date)),DAY)/365.0,2) AS customer_lifespan_days
+FROM {{ref("int_ae_local_bike__orders")}} o
+LEFT JOIN {{ref("int_ae_local_bike__order_items")}} oi on o.order_id = oi.order_id
+GROUP BY 
+    o.customer_id,
+    o.store_name

--- a/models/mart/mrt_ae_local_bike__missing_products_per_store.sql
+++ b/models/mart/mrt_ae_local_bike__missing_products_per_store.sql
@@ -1,0 +1,21 @@
+WITH items_to_ship AS (
+  SELECT
+    o.order_id,
+    oi.product_id,
+    oi.item_quantity
+  FROM {{ref("int_ae_local_bike__orders")}} o
+  LEFT JOIN {{ref("stg_ae_local_bike__order_items")}} oi ON o.order_id = oi.order_id
+  WHERE o.shipped_date IS NULL
+)
+
+SELECT
+    sk.store_name,
+    sk.product_name,
+    sk.product_id,
+    SUM(sk.quantity) AS item_stock,
+    SUM(its.item_quantity) AS nb_items_ordered,
+    SUM(sk.quantity) - SUM(its.item_quantity) AS stock_level
+FROM items_to_ship its
+LEFT JOIN {{ref("int_ae_local_bike__stocks")}} sk ON sk.product_id = its.product_id
+GROUP BY 1,2,3
+

--- a/models/mart/mrt_ae_local_bike__monthly_sales_performance.sql
+++ b/models/mart/mrt_ae_local_bike__monthly_sales_performance.sql
@@ -1,0 +1,14 @@
+SELECT
+  DATE_TRUNC(oi.order_date, MONTH) AS order_date,
+  o.store_name,
+  SUM(oi.total_order_item_amount) AS total_orders_amount,
+  AVG(oi.total_order_item_amount) AS avg_orders_amount,
+  SUM(oi.discount_amount) as total_discount_amount,
+  COUNT(DISTINCT oi.order_id) AS nb_orders,
+  COUNT(DISTINCT oi.order_item_id) AS nb_products_sold,
+  COUNT(DISTINCT oi.order_item_id)/COUNT(DISTINCT oi.order_id) AS avg_nb_item_per_order
+FROM {{ref("int_ae_local_bike__order_items")}} oi
+LEFT JOIN {{ref("int_ae_local_bike__orders")}} o ON oi.order_id = o.order_id
+GROUP BY 
+    oi.order_date,
+    o.store_name

--- a/models/mart/mrt_ae_local_bike__products_performance.sql
+++ b/models/mart/mrt_ae_local_bike__products_performance.sql
@@ -1,0 +1,22 @@
+WITH product_sales AS (
+  SELECT
+    product_id,
+    order_date,
+    SUM(item_quantity) AS items_sold,
+    SUM(total_order_item_amount) AS total_sales_amount,
+    SUM(discount_amount) AS total_discount_amount
+  FROM {{ref("int_ae_local_bike__order_items")}}
+  GROUP BY 
+    product_id,
+    order_date)
+
+SELECT
+    ps.order_date,
+    ps.product_id,
+    p.product_name,
+    p.category_name,
+    ps.items_sold,
+    ps.total_sales_amount,
+    ps.total_discount_amount
+FROM product_sales ps
+LEFT JOIN {{ref("int_ae_local_bike__products")}} p on ps.product_id = p.product_id

--- a/models/mart/mrt_ae_local_bike__shipping_status.sql
+++ b/models/mart/mrt_ae_local_bike__shipping_status.sql
@@ -1,0 +1,10 @@
+SELECT
+  order_id,
+  required_date,
+  shipped_date,
+  CASE
+    WHEN shipped_date > required_date OR (shipped_date IS NULL AND required_date < current_Date()) THEN "late shipment"
+    WHEN shipped_date <= required_date THEN "on time"
+    END
+  AS shipment_status
+FROM {{ref("int_ae_local_bike__orders")}}


### PR DESCRIPTION
Feat: Addition of 5 mart models in order to build a dashboard
Fix: rounding the discount amount in intermediate model order items and separating product id and product name in intermediate model product